### PR TITLE
Add auto-start for firmwares defined in uEnv.txt

### DIFF
--- a/board/t3/t3-gem-o1/t3-gem-o1.env
+++ b/board/t3/t3-gem-o1/t3-gem-o1.env
@@ -32,5 +32,20 @@ args_mmc=setenv bootargs console=${console} ${optargs} root=/dev/mmcblk${mmcdev}
 boot_mmc=run get_kern_mmc; run get_fdt_mmc; run get_overlays; run get_initrd_mmc; booti ${loadaddr} ${initrdaddr}:${filesize} ${fdtaddr}
 bootcmd_mmc=run args_mmc; run boot_mmc
 
+app_tmp_loadaddr=0x90000000
+load_and_run_mcu_r5f=load ${bootdev} ${mmcdev}:1 ${app_tmp_loadaddr} mcu-fw/${mcu_r5f_firmware_name} && rproc init 0 && rproc load 0 ${app_tmp_loadaddr} ${filesize} && rproc start 0 && echo "MCU R5 core started with ${mcu_r5f_firmware_name} firmware";
+load_and_run_wkup_r5f=load ${bootdev} ${mmcdev}:1 ${app_tmp_loadaddr} mcu-fw/${wkup_r5f_firmware_name} && rproc init 1 && rproc load 1 ${app_tmp_loadaddr} ${filesize} && rproc start 1 && echo "Wkup R5 core started with ${wkup_r5f_firmware_name} firmware";
+load_and_run_main_r5f=load ${bootdev} ${mmcdev}:1 ${app_tmp_loadaddr} mcu-fw/${main_r5f_firmware_name} && rproc init 2 && rproc load 2 ${app_tmp_loadaddr} ${filesize} && rproc start 2 && echo "Main R5 core started with ${main_r5f_firmware_name} firmware";
+load_and_run_c7x0_dsp=load ${bootdev} ${mmcdev}:1 ${app_tmp_loadaddr} mcu-fw/${c7x0_dsp_firmware_name} && rproc init 3 && rproc load 3 ${app_tmp_loadaddr} ${filesize} && rproc start 3 && echo "C7x0 DSP core started with ${c7x0_dsp_firmware_name} firmware";
+load_and_run_c7x1_dsp=load ${bootdev} ${mmcdev}:1 ${app_tmp_loadaddr} mcu-fw/${c7x1_dsp_firmware_name} && rproc init 4 && rproc load 4 ${app_tmp_loadaddr} ${filesize} && rproc start 4 && echo "C7x1 DSP core started with ${c7x1_dsp_firmware_name} firmware";
+
+check_and_run_mcu_r5f=if test "${mcu_r5f_firmware_name}" != ""; then run load_and_run_mcu_r5f; fi
+check_and_run_main_r5f=if test "${main_r5f_firmware_name}" != ""; then run load_and_run_main_r5f; fi
+check_and_run_wkup_r5f=if test "${wkup_r5f_firmware_name}" != ""; then run load_and_run_wkup_r5f; fi
+check_and_run_c7x0_dsp=if test "${c7x0_dsp_firmware_name}" != ""; then run load_and_run_c7x0_dsp; fi
+check_and_run_c7x1_dsp=if test "${c7x1_dsp_firmware_name}" != ""; then run load_and_run_c7x1_dsp; fi
+
+check_and_run_cores=run check_and_run_main_r5f; run check_and_run_mcu_r5f; check_and_run_wkup_r5f; check_and_run_c7x0_dsp; check_and_run_c7x1_dsp;
+
 bootdev=mmc
-distro_bootcmd=mmc dev ${mmcdev}; setenv bootpart ${mmcdev}:1; run bootcmd_${bootdev}
+distro_bootcmd=run check_and_run_cores; mmc dev ${mmcdev}; setenv bootpart ${mmcdev}:1; run bootcmd_${bootdev}


### PR DESCRIPTION
Add support for automatically starting remote processor firmwares during the U-Boot stage instead of waiting for Linux boot completion. Firmware names are specified in /boot/uEnv.txt using core-specific variables:
- main_r5f_firmware_name
- mcu_r5f_firmware_name
- wkup_r5f_firmware_name
- c7x0_dsp_firmware_name
- c7x1_dsp_firmware_name

This reduces boot delays by starting remote cores earlier in the boot process.